### PR TITLE
feat: pull osekai data from DB instead of api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1304,6 +1304,7 @@ dependencies = [
  "clap",
  "dotenv",
  "eyre",
+ "futures-util",
  "http",
  "hyper",
  "hyper-rustls 0.24.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ bytes = { version = "1.0" }
 clap = { version = "4.0", default-features = false, features = ["derive", "help", "std", "usage"] }
 dotenv = { version = "0.15" }
 eyre = { version = "0.6" }
+futures-util = { version = "0.3", default-features = false, features = ["std"] }
 http = { version = "0.2" }
 hyper = { version = "0.14", default-features = false }
 hyper-rustls = { version = "0.24", default-features = false, features = ["http1", "tls12", "tokio-runtime", "webpki-tokio"] }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -68,42 +68,6 @@ impl Client {
         }
     }
 
-    /// Request all medals stored by osekai
-    pub async fn get_osekai_medals(&self) -> Result<Bytes> {
-        let url = format!("{base}down_medals.php", base = Config::get().url_base);
-
-        self.send_get_request_retry(url).await
-    }
-
-    /// Request all badges stored by osekai
-    pub async fn get_osekai_badges(&self) -> Result<Bytes> {
-        let url = format!("{base}down_badges.php", base = Config::get().url_base);
-
-        self.send_get_request_retry(url).await
-    }
-
-    /// Request all user ids stored by osekai
-    pub async fn get_osekai_members(&self) -> Result<Bytes> {
-        let url = format!("{base}down_members.php", base = Config::get().url_base);
-
-        self.send_get_request_retry(url).await
-    }
-
-    /// Request all ranking user ids stored by osekai
-    pub async fn get_osekai_ranking(&self) -> Result<Bytes> {
-        let url = format!("{base}down_ranking_ids.php", base = Config::get().url_base);
-
-        self.send_get_request_retry(url).await
-    }
-
-    /// Request all medal rarities stored by osekai
-    pub async fn get_osekai_rarities(&self) -> Result<Bytes> {
-        let base = &Config::get().url_base;
-        let url = format!("{base}down_rarity.php");
-
-        self.send_get_request_retry(url).await
-    }
-
     /// Keep osekai posted on what the current progress is
     pub async fn upload_progress(&self, progress: &Progress) -> Result<OsekaiResponse> {
         let url = format!("{base}progression.php", base = Config::get().url_base);

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -84,15 +84,6 @@ impl Client {
         OsekaiResponse::new(bytes)
     }
 
-    async fn send_get_request_retry(&self, url: impl AsRef<str>) -> Result<Bytes> {
-        let url = url.as_ref();
-
-        match self.send_get_request(url).await {
-            Ok(bytes) => Ok(bytes),
-            Err(_) => self.send_get_request(url).await,
-        }
-    }
-
     async fn send_get_request(&self, url: &str) -> Result<Bytes> {
         trace!("Sending GET request to url {url}");
 

--- a/src/context/medal.rs
+++ b/src/context/medal.rs
@@ -10,7 +10,6 @@ use serde::{
     de::{DeserializeSeed, Error as SerdeError, IgnoredAny, MapAccess, SeqAccess, Visitor},
     Deserializer as DeserializerTrait,
 };
-use serde_json::{de::SliceRead, Deserializer};
 
 use crate::{
     model::{MedalRarities, OsuUser, ScrapedMedal, ScrapedUser},
@@ -43,37 +42,6 @@ impl Context {
             .with_context(|| format!("failed to deserialize scraped data: {data}"))?;
 
         Ok(deserialized.medals)
-    }
-
-    pub async fn request_osekai_medals(&self) -> Result<HashSet<u16, IntHasher>> {
-        let bytes = self
-            .client
-            .get_osekai_medals()
-            .await
-            .context("failed to get osekai medals")?;
-
-        Deserializer::new(SliceRead::new(&bytes))
-            .deserialize_seq(MedalsVisitor)
-            .with_context(|| {
-                let text = String::from_utf8_lossy(&bytes);
-
-                format!("failed to deserialize osekai medals: {text}")
-            })
-    }
-
-    /// Request all medal rarities stored by osekai
-    pub async fn request_osekai_rarities(&self) -> Result<MedalRarities> {
-        let bytes = self
-            .client
-            .get_osekai_rarities()
-            .await
-            .context("failed to get osekai rarities")?;
-
-        serde_json::from_slice(&bytes).with_context(|| {
-            let text = String::from_utf8_lossy(&bytes);
-
-            format!("failed to deserialize osekai rarities: {text}")
-        })
     }
 
     /// Calculate each medal's rarity i.e. how many users obtained it

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -195,8 +195,8 @@ impl Context {
 
         // If really ALL users are wanted, get them from osekai
         if task.contains(Task::FULL) && !args.debug {
-            if let Err(err) = self.request_osekai_ranking(&mut user_ids).await {
-                error!("{:?}", err.wrap_err("Failed to get osekai ranking"));
+            if let Err(err) = self.mysql.fetch_osekai_ranking_ids(&mut user_ids).await {
+                error!(?err, "Failed to fetch osekai ranking ids");
             }
         }
 

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -165,9 +165,9 @@ impl Context {
         task: Task,
         args: &Args,
     ) -> (Vec<OsuUser>, Badges, Progress) {
-        // If medals are the only thing that should be updated, requesting users is not necessary
+        // If medals are the only thing that should be updated, fetching users is not necessary
         let mut user_ids = if task != Task::MEDALS {
-            // Otherwise request the user ids stored by osekai
+            // Otherwise fetch the user ids stored by osekai
             match self.mysql.fetch_osekai_user_ids().await {
                 Ok(users) => users,
                 Err(err) => {
@@ -193,7 +193,7 @@ impl Context {
             self.request_leaderboards(&mut user_ids, pages).await;
         }
 
-        // If really ALL users are wanted, get them from osekai
+        // If really ALL users are wanted, fetch them from osekai
         if task.contains(Task::FULL) && !args.debug {
             if let Err(err) = self.mysql.fetch_osekai_ranking_ids(&mut user_ids).await {
                 error!(?err, "Failed to fetch osekai ranking ids");
@@ -203,7 +203,7 @@ impl Context {
         // In case additional user ids were given through CLI, add them here
         user_ids.extend(&args.extras);
 
-        // Request badges stored by osekai so we know their ID and can extend the users
+        // Fetch badges stored by osekai so we know their ID and can extend the users
         let (check_badges, stored_badges) = if task.badges() {
             match self.mysql.fetch_badges().await {
                 Ok(badges) => (true, badges),
@@ -328,7 +328,7 @@ impl Context {
             Self::calculate_rarities(&users, medals)
         } else if task.ranking() {
             // Only osekai users were retrieved, dont calculate rarities
-            // and instead just request them from osekai
+            // and instead just fetch them from osekai
             match self.mysql.fetch_medal_rarities().await {
                 Ok(rarities) => rarities,
                 Err(err) => return error!(?err, "Failed to fetch medal rarities from DB"),

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -205,10 +205,10 @@ impl Context {
 
         // Request badges stored by osekai so we know their ID and can extend the users
         let (check_badges, stored_badges) = if task.badges() {
-            match self.request_osekai_badges().await {
+            match self.mysql.fetch_badges().await {
                 Ok(badges) => (true, badges),
                 Err(err) => {
-                    error!("{:?}", err.wrap_err("Failed to get osekai badges"));
+                    error!(?err, "Failed to fetch badges from DB");
 
                     (false, Vec::new())
                 }

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -168,10 +168,10 @@ impl Context {
         // If medals are the only thing that should be updated, requesting users is not necessary
         let mut user_ids = if task != Task::MEDALS {
             // Otherwise request the user ids stored by osekai
-            match self.request_osekai_users().await {
+            match self.mysql.fetch_osekai_user_ids().await {
                 Ok(users) => users,
                 Err(err) => {
-                    error!("{:?}", err.wrap_err("Failed to request osekai users"));
+                    error!(?err, "Failed to fetch osekai user ids");
 
                     HashSet::with_hasher(IntHasher)
                 }

--- a/src/context/user.rs
+++ b/src/context/user.rs
@@ -111,21 +111,6 @@ impl Context {
         info!("Finished requesting {max_page} leaderboard pages for all modes");
     }
 
-    /// Request all user ids stored by osekai
-    pub async fn request_osekai_users(&self) -> Result<HashSet<u32, IntHasher>> {
-        let bytes = self
-            .client
-            .get_osekai_members()
-            .await
-            .context("failed to get osekai members")?;
-
-        serde_json::from_slice(&bytes).with_context(|| {
-            let text = String::from_utf8_lossy(&bytes);
-
-            format!("failed to deserialize osekai members: {text}")
-        })
-    }
-
     pub async fn request_osekai_ranking(
         &self,
         user_ids: &mut HashSet<u32, IntHasher>,

--- a/src/context/user.rs
+++ b/src/context/user.rs
@@ -15,7 +15,7 @@ use serde::{
 use serde_json::{de::SliceRead, Deserializer};
 
 use crate::{
-    model::{OsuUser, SlimBadge, UserFull},
+    model::{OsuUser, UserFull},
     util::{Eta, IntHasher},
 };
 
@@ -142,31 +142,6 @@ impl Context {
                 let text = String::from_utf8_lossy(&bytes);
 
                 format!("failed to deserialize osekai ranking: {text}")
-            })
-    }
-
-    /// Request all badges stored by osekai.
-    ///
-    /// The resulting badges will be sorted by their description.
-    pub async fn request_osekai_badges(&self) -> Result<Vec<SlimBadge>> {
-        let bytes = self
-            .client
-            .get_osekai_badges()
-            .await
-            .context("failed to get osekai badges")?;
-
-        serde_json::from_slice(&bytes)
-            // Collecting into a Vec followed by sorting appears to be a tiny bit faster than
-            // collecting into a BinaryHeap followed by converting into a Vec
-            .map(|mut badges: Vec<SlimBadge>| {
-                badges.sort_unstable();
-
-                badges
-            })
-            .with_context(|| {
-                let text = String::from_utf8_lossy(&bytes);
-
-                format!("failed to deserialize osekai badges: {text}")
             })
     }
 }

--- a/src/database/fetch.rs
+++ b/src/database/fetch.rs
@@ -1,13 +1,66 @@
 use std::{collections::HashSet, ops::DerefMut};
 
-use eyre::{Context as _, Result};
-use futures_util::TryStreamExt;
+use eyre::{Context as _, Report, Result};
+use futures_util::{StreamExt, TryStreamExt};
 
-use crate::{model::MedalRarities, util::IntHasher};
+use crate::{
+    model::{MedalRarities, SlimBadge},
+    util::IntHasher,
+};
 
 use super::Database;
 
 impl Database {
+    /// The resulting badges will be sorted by their description.
+    pub async fn fetch_badges(&self) -> Result<Vec<SlimBadge>> {
+        let mut conn = self
+            .acquire()
+            .await
+            .context("failed to acquire connection to fetch badges")?;
+
+        let query = sqlx::query!(
+            r#"
+SELECT 
+  id, 
+  description, 
+  users, 
+  image_url 
+FROM 
+  Badges"#
+        );
+
+        let mut badges: Vec<_> = query
+            .fetch(conn.deref_mut())
+            .map(|res| {
+                let row = res?;
+
+                let users = row
+                    .users
+                    .strip_prefix('[')
+                    .and_then(|suffix| suffix.strip_suffix(']'))
+                    .ok_or(Report::msg("expected square brackets in users string"))?
+                    .split(',')
+                    .map(str::trim)
+                    .map(str::parse)
+                    .collect::<Result<Box<[_]>, _>>()
+                    .map_err(|_| eyre!("failed to parse id in users string"))?;
+
+                Ok::<_, Report>(SlimBadge {
+                    id: row.id as u32,
+                    description: row.description.into_boxed_str(),
+                    users,
+                    image_url: row.image_url.into_boxed_str(),
+                })
+            })
+            .try_collect()
+            .await
+            .context("failed to fetch all badges")?;
+
+        badges.sort_unstable();
+
+        Ok(badges)
+    }
+
     pub async fn fetch_medal_rarities(&self) -> Result<MedalRarities> {
         let mut conn = self
             .acquire()

--- a/src/database/fetch.rs
+++ b/src/database/fetch.rs
@@ -11,6 +11,28 @@ use crate::{
 use super::Database;
 
 impl Database {
+    pub async fn fetch_osekai_user_ids(&self) -> Result<HashSet<u32, IntHasher>> {
+        let mut conn = self
+            .acquire()
+            .await
+            .context("failed to acquire connection to fetch user ids")?;
+
+        let query = sqlx::query!(
+            r#"
+SELECT 
+  id 
+FROM 
+  Members"#
+        );
+
+        query
+            .fetch(conn.deref_mut())
+            .map_ok(|row| row.id as u32)
+            .try_collect()
+            .await
+            .context("failed to fetch all user ids")
+    }
+
     /// The resulting badges will be sorted by their description.
     pub async fn fetch_badges(&self) -> Result<Vec<SlimBadge>> {
         let mut conn = self

--- a/src/database/fetch.rs
+++ b/src/database/fetch.rs
@@ -1,0 +1,56 @@
+use std::{collections::HashSet, ops::DerefMut};
+
+use eyre::{Context as _, Result};
+use futures_util::TryStreamExt;
+
+use crate::{model::MedalRarities, util::IntHasher};
+
+use super::Database;
+
+impl Database {
+    pub async fn fetch_medal_rarities(&self) -> Result<MedalRarities> {
+        let mut conn = self
+            .acquire()
+            .await
+            .context("failed to acquire connection to fetch medal rarities")?;
+
+        let query = sqlx::query!(
+            r#"
+SELECT 
+  id, 
+  frequency, 
+  count 
+FROM 
+  MedalRarity"#
+        );
+
+        query
+            .fetch(conn.deref_mut())
+            .map_ok(|row| (row.id as u16, row.count as u32, row.frequency))
+            .try_collect()
+            .await
+            .context("failed to fetch all medal rarities")
+    }
+
+    pub async fn fetch_medal_ids(&self) -> Result<HashSet<u16, IntHasher>> {
+        let mut conn = self
+            .acquire()
+            .await
+            .context("failed to acquire connection to fetch medal ids")?;
+
+        let query = sqlx::query!(
+            r#"
+SELECT 
+  medalid 
+FROM 
+  Medals"#
+        );
+
+        query
+            .fetch(conn.deref_mut())
+            .map_ok(|row| row.medalid as u16)
+            .try_collect()
+            .await
+            .context("failed to fetch all medal ids")
+    }
+}

--- a/src/database/fetch.rs
+++ b/src/database/fetch.rs
@@ -11,6 +11,36 @@ use crate::{
 use super::Database;
 
 impl Database {
+    pub async fn fetch_osekai_ranking_ids(
+        &self,
+        user_ids: &mut HashSet<u32, IntHasher>,
+    ) -> Result<()> {
+        let mut conn = self
+            .acquire()
+            .await
+            .context("failed to acquire connection to fetch ranking ids")?;
+
+        let query = sqlx::query!(
+            r#"
+SELECT 
+  id 
+FROM 
+  Ranking"#
+        );
+
+        query
+            .fetch(conn.deref_mut())
+            .try_for_each(|row| {
+                user_ids.insert(row.id as u32);
+
+                std::future::ready(Ok(()))
+            })
+            .await
+            .context("failed to fetch all ranking ids")?;
+
+        Ok(())
+    }
+
     pub async fn fetch_osekai_user_ids(&self) -> Result<HashSet<u32, IntHasher>> {
         let mut conn = self
             .acquire()

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -1,0 +1,26 @@
+mod fetch;
+mod store;
+
+use eyre::{Context as _, Result};
+use sqlx::{pool::PoolConnection, Error as SqlxError, MySql, MySqlPool, Transaction};
+
+pub struct Database {
+    mysql: MySqlPool,
+}
+
+impl Database {
+    pub async fn new(url: &str) -> Result<Self> {
+        MySqlPool::connect(url)
+            .await
+            .map(|mysql| Self { mysql })
+            .context("failed to connect to database")
+    }
+
+    async fn acquire(&self) -> Result<PoolConnection<MySql>, SqlxError> {
+        self.mysql.acquire().await
+    }
+
+    async fn begin(&self) -> Result<Transaction<'_, MySql>, SqlxError> {
+        self.mysql.begin().await
+    }
+}

--- a/src/database/store.rs
+++ b/src/database/store.rs
@@ -1,28 +1,14 @@
 use std::ops::DerefMut;
 
 use eyre::{Context as _, Result};
-use sqlx::{Error as SqlxError, MySql, MySqlPool, Transaction};
 
 use crate::model::{
     BadgeEntry, BadgeKey, Badges, MedalRarities, MedalRarityEntry, RankingUser, ScrapedMedal,
 };
 
-pub struct Database {
-    mysql: MySqlPool,
-}
+use super::Database;
 
 impl Database {
-    pub async fn new(url: &str) -> Result<Self> {
-        MySqlPool::connect(url)
-            .await
-            .map(|mysql| Self { mysql })
-            .context("failed to connect to database")
-    }
-
-    async fn begin(&self) -> Result<Transaction<'_, MySql>, SqlxError> {
-        self.mysql.begin().await
-    }
-
     pub async fn store_rankings(&self, rankings: &[RankingUser]) -> Result<()> {
         let mut tx = self
             .begin()

--- a/src/model/rarity.rs
+++ b/src/model/rarity.rs
@@ -1,12 +1,6 @@
 use std::{
     collections::{hash_map::Iter, HashMap},
-    fmt::{Formatter, Result as FmtResult},
     iter::FromIterator,
-};
-
-use serde::{
-    de::{DeserializeSeed, Error as SerdeError, MapAccess, SeqAccess, Visitor},
-    Deserialize, Deserializer,
 };
 
 use crate::util::IntHasher;
@@ -55,79 +49,12 @@ impl FromIterator<(u16, u32, f32)> for MedalRarities {
     }
 }
 
-impl<'de> Deserialize<'de> for MedalRarities {
-    #[inline]
-    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
-        d.deserialize_seq(MedalRaritiesVisitor)
-    }
-}
+impl Extend<(u16, u32, f32)> for MedalRarities {
+    fn extend<T: IntoIterator<Item = (u16, u32, f32)>>(&mut self, iter: T) {
+        let iter = iter
+            .into_iter()
+            .map(|(medal_id, count, frequency)| (medal_id, MedalRarityEntry { count, frequency }));
 
-struct MedalRaritiesVisitor;
-
-impl<'de> Visitor<'de> for MedalRaritiesVisitor {
-    type Value = MedalRarities;
-
-    fn expecting(&self, f: &mut Formatter<'_>) -> FmtResult {
-        f.write_str("a list of medal rarities")
-    }
-
-    #[inline]
-    fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
-        let capacity = seq.size_hint().unwrap_or(0);
-        let mut inner = HashMap::with_capacity_and_hasher(capacity, IntHasher);
-
-        while seq.next_element_seed(RaritySeed(&mut inner))?.is_some() {}
-
-        Ok(MedalRarities { inner })
-    }
-}
-
-struct RaritySeed<'m>(&'m mut HashMap<u16, MedalRarityEntry, IntHasher>);
-
-impl<'de> DeserializeSeed<'de> for RaritySeed<'_> {
-    type Value = ();
-
-    #[inline]
-    fn deserialize<D: Deserializer<'de>>(self, d: D) -> Result<Self::Value, D::Error> {
-        d.deserialize_map(self)
-    }
-}
-
-impl<'de> Visitor<'de> for RaritySeed<'_> {
-    type Value = ();
-
-    fn expecting(&self, f: &mut Formatter<'_>) -> FmtResult {
-        f.write_str("a map containing `id`, `frequency`, and `count` fields")
-    }
-
-    fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
-        let mut medal_id = None;
-        let mut frequency = None;
-        let mut count = None;
-
-        while let Some(key) = map.next_key()? {
-            match key {
-                "id" => medal_id = Some(map.next_value()?),
-                "frequency" => frequency = Some(map.next_value()?),
-                "count" => count = Some(map.next_value()?),
-                _ => {
-                    return Err(SerdeError::unknown_field(
-                        key,
-                        &["id", "frequency", "count"],
-                    ))
-                }
-            }
-        }
-
-        let medal_id = medal_id.ok_or_else(|| SerdeError::missing_field("medalid"))?;
-
-        let entry = MedalRarityEntry {
-            count: count.ok_or_else(|| SerdeError::missing_field("count"))?,
-            frequency: frequency.ok_or_else(|| SerdeError::missing_field("frequency"))?,
-        };
-
-        self.0.insert(medal_id, entry);
-
-        Ok(())
+        self.inner.extend(iter)
     }
 }


### PR DESCRIPTION
This PR replaces all requests to `down_*` endpoints with fetching directly from a DB.