### PR TITLE
Fix Apple Silicon compilation

### DIFF
--- a/src/util/args.rs
+++ b/src/util/args.rs
@@ -98,6 +98,9 @@ fn update() -> Result<Status> {
     #[cfg(target_os = "linux")]
     let target = "x86_64-unknown-linux-musl";
 
+    #[cfg(target_os = "macos")]
+    let target = "stable-aarch64-apple-darwin";
+
     Update::configure()
         .repo_owner("Osekai")
         .repo_name("scripts-rust")

--- a/src/util/args.rs
+++ b/src/util/args.rs
@@ -1,8 +1,8 @@
 use std::{collections::HashSet, ops::BitOr};
 
 use clap::{Parser, Subcommand};
-use eyre::{Result, WrapErr};
-use self_update::{backends::github::Update, Status};
+use eyre::Result;
+use self_update::Status;
 
 use crate::task::Task;
 
@@ -91,17 +91,10 @@ enum ArgCommand {
     Update,
 }
 
+#[cfg(any(target_os = "windows", target_os = "linux"))]
 fn update() -> Result<Status> {
-    #[cfg(target_os = "windows")]
-    let target = "x86_64-pc-windows-gnu";
-
-    #[cfg(target_os = "linux")]
-    let target = "x86_64-unknown-linux-musl";
-
-    #[cfg(target_os = "macos")]
-    let target = "stable-aarch64-apple-darwin";
-
-    Update::configure()
+	use eyre::WrapErr;
+    self_update::backends::github::Update::configure()
         .repo_owner("Osekai")
         .repo_name("scripts-rust")
         .bin_name("osekai-scripts")
@@ -114,6 +107,11 @@ fn update() -> Result<Status> {
         .wrap_err("Failed to build update")?
         .update()
         .wrap_err("Failed to apply update")
+}
+
+#[cfg(not(any(target_os = "windows", target_os = "linux")))]
+fn update() -> Result<Status> {
+    panic!("Updating is currently only supported on Windows and Linux.")
 }
 
 static DESCRIPTION: &str = r#"


### PR DESCRIPTION
When building on a Mac with Apple Silicon, you get a compilation error
```
error[E0425]: cannot find value `target` in this scope
   --> src/util/args.rs:109:17
    |
109 |         .target(target)
    |                 ^^^^^^ not found in this scope

For more information about this error, try `rustc --explain E0425`.
error: could not compile `osekai-scripts` (bin "osekai-scripts") due to previous error
```
this seems to be derived from the fact that there's no macos build flag in this block (src/utils/args.rs under update()):
```rs
#[cfg(target_os = "windows")]
let target = "x86_64-pc-windows-gnu";

#[cfg(target_os = "linux")]
let target = "x86_64-unknown-linux-musl";
```
Apple Silicon uses the `stable-aarch64-apple-darwin` target by default, as evidenced here:
<img width="325" alt="Screenshot 2023-08-14 at 11 57 04" src="https://github.com/Osekai/scripts-rust/assets/65419194/728f9a50-ff77-43f3-8b3f-231d123b5f72">

I added this block:
```rs
#[cfg(target_os = "macos")]
let target = "stable-aarch64-apple-darwin";
```
Which fixes compilation as shown here (I don't have a .env, but it does compile now)
<img width="795" alt="Screenshot 2023-08-14 at 11 58 32" src="https://github.com/Osekai/scripts-rust/assets/65419194/d37a591d-9cce-424e-8e8b-94f20f334946">

